### PR TITLE
Demonstrate inability to re-use functions

### DIFF
--- a/dbt_python_model_testing_exploration/models/example/customer_total_order_price.py
+++ b/dbt_python_model_testing_exploration/models/example/customer_total_order_price.py
@@ -1,9 +1,16 @@
+from models.example.customer_orders import include_sales_tax
+
+
 def model(dbt, session):
     dbt.config(materialized="table")
     customer_orders_df = dbt.ref("customer_orders")
     pandas_df = (
         customer_orders_df.filter("O_TOTALPRICE is not null")
         .select(["C_CUSTKEY", "O_TOTALPRICE"])
+        .withColumn(
+            "O_TOTALPRICE_WITH_TAX",
+            include_sales_tax(customer_orders_df.col("O_TOTALPRICE")),
+        )
         .to_pandas()
     )
     # I don't know pandas enough to know why I have to do reset_index

--- a/dbt_python_model_testing_exploration/tests/unit/test_customer_total_order_price.py
+++ b/dbt_python_model_testing_exploration/tests/unit/test_customer_total_order_price.py
@@ -28,7 +28,7 @@ def test_customer_total_order_price(unit_test_session):
     result_df = unit_test_session.create_dataframe(result_pandas_df)
 
     expected_df = unit_test_session.create_dataframe(
-        [[1, 300.00], [3, 600.00]],
-        schema=["c_custkey", "o_totalprice"],
+        [[1, 300.00, 322.50], [3, 600.00, 645.00]],
+        schema=["c_custkey", "o_totalprice", "o_totalprice_with_tax"],
     )
     assert result_df.collect() == expected_df.collect()


### PR DESCRIPTION
As mentioned here (as of 11-Oct-2022): https://docs.getdbt.com/docs/building-a-dbt-project/building-models/python-models#code-reuse

```
Currently, Python functions defined in one dbt model cannot be imported and reused in other models.
```

We this currently when trying to execute `dbt run`, even though the unit tests actually succeed:

```
>dbt run --model customer_total_order_price.py
17:45:14  Running with dbt=1.3.0-rc2
17:45:14  Found 4 models, 0 tests, 0 snapshots, 0 analyses, 303 macros, 0 operations, 0 seed files, 2 sources, 0 exposures, 0 metrics
17:45:14
17:45:17  Concurrency: 1 threads (target='dev')
17:45:17
17:45:17  1 of 1 START python table model transform.customer_total_order_price ........... [RUN]
17:45:22  1 of 1 ERROR creating python table model transform.customer_total_order_price .. [ERROR in 4.87s]
17:45:22
17:45:22  Finished running 1 table model in 0 hours 0 minutes and 7.38 seconds (7.38s).
17:45:22
17:45:22  Completed with 1 error and 0 warnings:
17:45:22
17:45:22  Database Error in model customer_total_order_price (models\example\customer_total_order_price.py)
17:45:22    100357 (P0000): Python Interpreter Error:
17:45:22    Traceback (most recent call last):
17:45:22      File "_udf_code.py", line 5, in <module>
17:45:22    ModuleNotFoundError: No module named 'models'
17:45:22     in function CUSTOMER_TOTAL_ORDER_PRICE__DBT_SP with handler main
17:45:22    compiled Code at target\run\dbt_python_model_testing_exploration\models\example\customer_total_order_price.py
17:45:22
17:45:22  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
```