### PR TITLE
Move function that calculates tax to a UDF created via on-run-start

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,3 +30,4 @@ jobs:
         python -m pytest tests
       env:
         SNOWFLAKE_CONN_STR: ${{ secrets.SNOWFLAKE_CONN_STR }}
+        SNOWFLAKE_TARGET_SCHEMA: ${{ secrets.SNOWFLAKE_TARGET_SCHEMA }}

--- a/README.md
+++ b/README.md
@@ -18,10 +18,18 @@ We then set the `SNOWFLAKE_CONN_STR` variable with content similar to:
 {"account":"accountid.us-east-1","user":"transform_user","password":"password_here","warehouse":"warehouse_id","database":"database_id","schema":"schema_id","role":"role_id"}
 ```
 
+Since this repo has UDFs being created via macro in on-run-start, the unit tests rely on those UDFs already existing.
+We expect them to be in the schema pointed to by the `SNOWFLAKE_TARGET_SCHEMA` variable, which should have content similar to:
+
+```
+database_id.schema_id
+```
+
 For local testing, a `pytest.ini` file can be added with content similar to:
 
 ```
 [pytest]
 env =
     SNOWFLAKE_CONN_STR={{"account":"accountid.us-east-1","user":"transform_user","password":"password_here","warehouse":"warehouse_id","database":"database_id","schema":"schema_id","role":"role_id"}}
+    SNOWFLAKE_TARGET_SCHEMA=database_id.schema_id
 ```

--- a/dbt_python_model_testing_exploration/dbt_project.yml
+++ b/dbt_python_model_testing_exploration/dbt_project.yml
@@ -36,3 +36,6 @@ models:
     # Config indicated by + and applies to all files under models/example/
     example:
       +materialized: view
+
+on-run-start:
+  - '{{ create_include_sales_tax_udf()}}'

--- a/dbt_python_model_testing_exploration/macros/create_include_sales_tax_udf.sql
+++ b/dbt_python_model_testing_exploration/macros/create_include_sales_tax_udf.sql
@@ -13,7 +13,7 @@ $$
 
 def include_sales_tax(amount):
     # assumes 7.5% tax
-    return amount * 1.075
+    return amount * 1.075 if amount else 0.0
 $$
 ;
 

--- a/dbt_python_model_testing_exploration/macros/create_include_sales_tax_udf.sql
+++ b/dbt_python_model_testing_exploration/macros/create_include_sales_tax_udf.sql
@@ -1,0 +1,20 @@
+{% macro create_include_sales_tax_udf() %}
+
+drop function if exists {{target.schema}}.include_sales_tax(float);
+
+create function if not exists {{target.schema}}.include_sales_tax(amount float)
+returns float
+language python
+runtime_version = '3.8'
+handler = 'include_sales_tax'
+as
+
+$$
+
+def include_sales_tax(amount):
+    # assumes 7.5% tax
+    return amount * 1.075
+$$
+;
+
+{% endmacro %}

--- a/dbt_python_model_testing_exploration/models/example/customer_orders.py
+++ b/dbt_python_model_testing_exploration/models/example/customer_orders.py
@@ -15,7 +15,12 @@ def model(dbt, session):
     )
     joined_df = joined_df.withColumn(
         "o_totalprice_with_tax",
-        snowparkround(call_udf("include_sales_tax", joined_df.col("o_totalprice")), 2),
+        snowparkround(
+            call_udf(
+                f"{dbt.this.schema}.include_sales_tax", joined_df.col("o_totalprice")
+            ),
+            2,
+        ),
     )
     return joined_df.select(
         [

--- a/dbt_python_model_testing_exploration/models/example/customer_orders.py
+++ b/dbt_python_model_testing_exploration/models/example/customer_orders.py
@@ -1,3 +1,7 @@
+from snowflake.snowpark.functions import call_udf
+from snowflake.snowpark.functions import round as snowparkround
+
+
 def model(dbt, session):
     dbt.config(materialized="table")
 
@@ -11,9 +15,7 @@ def model(dbt, session):
     )
     joined_df = joined_df.withColumn(
         "o_totalprice_with_tax",
-        include_sales_tax(
-            joined_df.col("o_totalprice")
-        ),  # how do I call this UDF that's now created in a macro?  we don't "register" anything with the session do we?
+        snowparkround(call_udf("include_sales_tax", joined_df.col("o_totalprice")), 2),
     )
     return joined_df.select(
         [

--- a/dbt_python_model_testing_exploration/models/example/customer_orders.py
+++ b/dbt_python_model_testing_exploration/models/example/customer_orders.py
@@ -1,11 +1,3 @@
-from snowflake.snowpark.functions import round as snowparkround
-
-
-def include_sales_tax(amount):
-    # assumes 7.5% tax
-    return snowparkround(amount * 1.075, 2)
-
-
 def model(dbt, session):
     dbt.config(materialized="table")
 
@@ -18,7 +10,10 @@ def model(dbt, session):
         join_type="left",
     )
     joined_df = joined_df.withColumn(
-        "o_totalprice_with_tax", include_sales_tax(joined_df.col("o_totalprice"))
+        "o_totalprice_with_tax",
+        include_sales_tax(
+            joined_df.col("o_totalprice")
+        ),  # how do I call this UDF that's now created in a macro?  we don't "register" anything with the session do we?
     )
     return joined_df.select(
         [

--- a/dbt_python_model_testing_exploration/tests/unit/test_customer_orders.py
+++ b/dbt_python_model_testing_exploration/tests/unit/test_customer_orders.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 from models.example.customer_orders import model
 from unit_test_snowpark_session import unit_test_session_fixture  # noqa: F401
+from unit_test_snowpark_session import get_target_schema
 
 
 def test_customer_orders(unit_test_session):
@@ -35,6 +36,9 @@ def test_customer_orders(unit_test_session):
 
     mock_dbt = Mock()
     mock_dbt.source = mock_source
+    mock_this = Mock()
+    mock_dbt.this = mock_this
+    mock_this.schema = get_target_schema()
     result_df = model(mock_dbt, unit_test_session)
 
     expected_df = unit_test_session.create_dataframe(
@@ -42,7 +46,7 @@ def test_customer_orders(unit_test_session):
             [1, "Customer 1", 123.45, 1, "P", 100.00, 107.50],
             [2, "Customer 2", 0.0, 2, "F", 1.00, 1.08],
             [2, "Customer 2", 0.0, 3, "O", 10.00, 10.75],
-            [3, "Customer 3 with no orders", 100.00, None, None, None, None],
+            [3, "Customer 3 with no orders", 100.00, None, None, None, 0.0],
         ],
         schema=[
             "C_CUSTKEY",
@@ -54,4 +58,8 @@ def test_customer_orders(unit_test_session):
             "O_TOTALPRICE_WITH_TAX",
         ],
     )
-    assert result_df.collect() == expected_df.collect()
+    order_by_columns = ["C_CUSTKEY", "O_ORDERKEY"]
+    assert (
+        result_df.orderBy(order_by_columns).collect()
+        == expected_df.orderBy(order_by_columns).collect()
+    )

--- a/dbt_python_model_testing_exploration/tests/unit/unit_test_snowpark_session.py
+++ b/dbt_python_model_testing_exploration/tests/unit/unit_test_snowpark_session.py
@@ -17,3 +17,13 @@ def unit_test_session_fixture():
     session = Session.builder.configs(connection_config).create()
     session.add_packages("numpy")
     return session
+
+
+def get_target_schema():
+    # gets the schema where all the functions are found
+    env_var = "SNOWFLAKE_TARGET_SCHEMA"  # See README for info on configuring this
+    target_schema = os.getenv(env_var)
+    assert (
+        target_schema is not None and len(target_schema) > 0
+    ), f"Expecting {target_schema} env var to be set"
+    return target_schema


### PR DESCRIPTION
This is a bit clunky, as the unit tests rely on the UDF already existing in some target schema.